### PR TITLE
redis sdk update

### DIFF
--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -111,14 +111,11 @@ func RedisInit(
 
 func DispatchRedisCall(
 	cluster string,
-	query string,
+	query []byte,
 	callBack func(status, responseSize int),
 ) (calloutID uint32, err error) {
-	qp := internal.StringBytePtr(query)
-	ql := len(query)
-
 	u := internal.StringBytePtr(cluster)
-	switch st := internal.ProxyRedisCall(u, len(cluster), qp, ql, &calloutID); st {
+	switch st := internal.ProxyRedisCall(u, len(cluster), &query[0], len(query), &calloutID); st {
 	case internal.StatusOK:
 		internal.RegisterRedisCallout(calloutID, callBack)
 		return calloutID, nil

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -57,6 +57,8 @@ type ProxyWasmHost interface {
 	ProxyGetBufferBytes(bufferType BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) Status
 	ProxySetBufferBytes(bufferType BufferType, start int, maxSize int, bufferData *byte, bufferSize int) Status
 	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) Status
+	ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int, passwordData *byte, passwordSize int, timeout uint32) Status
+	ProxyRedisCall(upstreamData *byte, upstreamSize int, queryData *byte, querySize int, calloutIDPtr *uint32) Status
 	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) Status
 	ProxySetTickPeriodMilliseconds(period uint32) Status
 	ProxySetEffectiveContext(contextID uint32) Status
@@ -128,6 +130,12 @@ func (d DefaultProxyWAMSHost) ProxySetBufferBytes(bufferType BufferType, start i
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int, passwordData *byte, passwordSize int, timeout uint32) Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxyRedisCall(upstreamData *byte, upstreamSize int, queryData *byte, querySize int, calloutIDPtr *uint32) Status {
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) Status {
@@ -232,6 +240,15 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, heade
 	bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) Status {
 	return currentHost.ProxyHttpCall(upstreamData, upstreamSize,
 		headerData, headerSize, bodyData, bodySize, trailersData, trailersSize, timeout, calloutIDPtr)
+}
+
+func ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int,
+	passwordData *byte, passwordSize int, timeout uint32) Status {
+	return currentHost.ProxyRedisInit(upstreamData, upstreamSize, usernameData, usernameSize, passwordData, passwordSize, timeout)
+}
+
+func ProxyRedisCall(upstreamData *byte, upstreamSize int, queryData *byte, querySize int, calloutIDPtr *uint32) Status {
+	return currentHost.ProxyRedisCall(upstreamData, upstreamSize, queryData, querySize, calloutIDPtr)
 }
 
 func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) Status {


### PR DESCRIPTION
1. `DispatchRedisCall` 方法参数 `query` 改为 `[]byte`，减少`string`和`[]byte`之间的转换
2. 增加mock，便于代码编写时的跳转