### PR TITLE
ProxyRedisInit and ProxyRedisCall functions are added in proxytest to enable the test framework to be used, but the logic is NOT actually implemented

### DIFF
--- a/proxywasm/proxytest/root.go
+++ b/proxywasm/proxytest/root.go
@@ -268,6 +268,21 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 }
 
 // impl internal.ProxyWasmHost
+func (r *rootHostEmulator) ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int, passwordData *byte, passwordSize int, timeout uint32) internal.Status {
+	upstream := internal.RawBytePtrToString(upstreamData, upstreamSize)
+	username := internal.RawBytePtrToString(usernameData, usernameSize)
+	password := internal.RawBytePtrToString(passwordData, passwordSize)
+
+	log.Printf("[redis init] upstream: %s", upstream)
+	log.Printf("[redis init] username: %s", username)
+	log.Printf("[redis init] password: %s", password)
+
+	//TODO: implement
+
+	return internal.StatusOK
+}
+
+// impl internal.ProxyWasmHost
 func (r *rootHostEmulator) ProxyRedisCall(commandData *byte, commandSize int, keyData *byte, keySize int,
 	elementData *byte, elementSize int, cas *uint32) internal.Status {
 	command := internal.RawBytePtrToString(commandData, commandSize)
@@ -277,6 +292,8 @@ func (r *rootHostEmulator) ProxyRedisCall(commandData *byte, commandSize int, ke
 	log.Printf("[redis call] command: %s", command)
 	log.Printf("[redis call] key: %s", key)
 	log.Printf("[redis call] element: %s", element)
+
+	// TODO: implement
 
 	return internal.StatusOK
 }

--- a/proxywasm/proxytest/root.go
+++ b/proxywasm/proxytest/root.go
@@ -268,6 +268,20 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 }
 
 // impl internal.ProxyWasmHost
+func (r *rootHostEmulator) ProxyRedisCall(commandData *byte, commandSize int, keyData *byte, keySize int,
+	elementData *byte, elementSize int, cas *uint32) internal.Status {
+	command := internal.RawBytePtrToString(commandData, commandSize)
+	key := internal.RawBytePtrToString(keyData, keySize)
+	element := internal.RawBytePtrToString(elementData, elementSize)
+
+	log.Printf("[redis call] command: %s", command)
+	log.Printf("[redis call] key: %s", key)
+	log.Printf("[redis call] element: %s", element)
+
+	return internal.StatusOK
+}
+
+// impl internal.ProxyWasmHost
 func (r *rootHostEmulator) RegisterForeignFunction(name string, f func([]byte) []byte) {
 	r.foreignFunctions[name] = f
 }


### PR DESCRIPTION
由于测试框架模拟器缺失`ProxyWasmHost`中redis相关特性的实现导致测试框架无法使用，故在测试框架中增加了两个占位函数，使测试框架可用。
**注意：Redis具体测试逻辑尚未补充**