### PR TITLE
use nottinygc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-参考：[proxy-wasm-go-sdk](https://github.com/tetratelabs/proxy-wasm-go-sdk)
+[tetratelabs/proxy-wasm-go-sdk](https://github.com/tetratelabs/proxy-wasm-go-sdk) has been archived due to memory leaks caused by the built-in garbage collector (gc) in TinyGo. 
 
-本repo为了方便Higress插件的开发者不需要在go.mod中手动replace包名，因此将包名进行了修改
+This repository is a stable alternative, where Higress has replaced TinyGo's built-in gc with [bdwgc](https://github.com/ivmai/bdwgc) (being used by large projects like Unity3D), largely avoiding the memory leak issue (though it still exists in extreme cases, such as: https://github.com/wasilibs/nottinygc/issues/46). 
+
+The Higress community has [40+ wasm plugins](https://higress.io/en/plugin/), and none of them have memory leak issues.
+
+Furthermore, Higress continues to optimize through [nottinygc](https://github.com/higress-group/nottinygc), which theoretically can prevent the memory leaks in those extreme scenarios.

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/higress-group/proxy-wasm-go-sdk
 go 1.19
 
 require (
+	github.com/higress-group/nottinygc v0.0.0-20231101025119-e93c4c2f8520
 	github.com/stretchr/testify v1.8.4
 	github.com/tetratelabs/wazero v1.6.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/magefile/mage v1.14.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/higress-group/nottinygc v0.0.0-20231101025119-e93c4c2f8520 h1:IHDghbGQ2DTIXHBHxWfqCYQW1fKjyJ/I7W1pMyUDeEA=
+github.com/higress-group/nottinygc v0.0.0-20231101025119-e93c4c2f8520/go.mod h1:Nz8ORLaFiLWotg6GeKlJMhv8cci8mM43uEnLA5t8iew=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -19,10 +19,16 @@ import (
 	"fmt"
 	"math"
 
+	_ "github.com/higress-group/nottinygc"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/internal"
 	_ "github.com/higress-group/proxy-wasm-go-sdk/proxywasm/internal/proxy_wasm_version/0_2_100/abi"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 )
+
+//export sched_yield
+func sched_yield() int32 {
+	return 0
+}
 
 // GetVMConfiguration is used for retrieving configurations given in the "vm_config.configuration" field.
 // This hostcall is only available during types.PluginContext.OnVMStart call.


### PR DESCRIPTION
Considering that tetrate is no longer maintaining the upstream repository, we have moved the nottinygc dependency from the [wasm-go](https://github.com/alibaba/higress/tree/main/plugins/wasm-go) lib used by higress here, to facilitate usage in other non-higress scenarios