### PR TITLE
Extend Go 1.24 wasm abi

### DIFF
--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -167,6 +167,52 @@ func DispatchHttpCall(
 	}
 }
 
+// InjectEncodedDataToFilterChain is used to inject encoded data to filter chain on response body phase
+func InjectEncodedDataToFilterChain(body []byte, endStream bool) error {
+	var bodyPtr *byte
+	if len(body) > 0 {
+		bodyPtr = &body[0]
+	}
+	switch st := internal.ProxyInjectEncodedDataToFilterChain(bodyPtr, len(body), endStream); st {
+	case internal.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("error occured when inject encoded data to filter chain")
+	}
+}
+
+// GetUpstreamHosts is used to get upstream cluster host address and metrics, the result format is [][2]string
+// For hosts with metrics, result example: {{"127.0.0.1:6000", "...prometheus metrics..."}}
+// For hosts without metrics, result example: {{"127.0.0.1:6000", ""}}
+func GetUpstreamHosts() ([][2]string, error) {
+	var rvs int
+	var raw *byte
+
+	st := internal.ProxyGetUpstreamHosts(&raw, &rvs)
+	if st != internal.StatusOK {
+		return nil, internal.StatusToError(st)
+	} else if raw == nil {
+		return nil, types.ErrorStatusNotFound
+	}
+
+	bs := internal.RawBytePtrToByteSlice(raw, rvs)
+	return internal.DeserializeMap(bs), nil
+}
+
+// SetUpstreamOverrideHost is used to set target endpoint
+func SetUpstreamOverrideHost(address []byte) error {
+	var addressPtr *byte
+	if len(address) > 0 {
+		addressPtr = &address[0]
+	}
+	switch st := internal.ProxySetUpstreamOverrideHost(addressPtr, len(address)); st {
+	case internal.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("error occured when override upstream host")
+	}
+}
+
 // GetHttpCallResponseHeaders is used for retrieving HTTP response headers
 // returned by a remote cluster in response to the DispatchHttpCall.
 // Only available during "callback" function passed to the DispatchHttpCall.

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -173,7 +173,7 @@ func InjectEncodedDataToFilterChain(body []byte, endStream bool) error {
 	if len(body) > 0 {
 		bodyPtr = &body[0]
 	}
-	switch st := internal.ProxyInjectEncodedDataToFilterChain(bodyPtr, len(body), endStream); st {
+	switch st := internal.ProxyInjectEncodedDataToFilterChain(bodyPtr, int32(len(body)), endStream); st {
 	case internal.StatusOK:
 		return nil
 	default:
@@ -185,17 +185,17 @@ func InjectEncodedDataToFilterChain(body []byte, endStream bool) error {
 // For hosts with metrics, result example: {{"127.0.0.1:6000", "...prometheus metrics..."}}
 // For hosts without metrics, result example: {{"127.0.0.1:6000", ""}}
 func GetUpstreamHosts() ([][2]string, error) {
-	var rvs int
+	var rvs int32
 	var raw *byte
 
-	st := internal.ProxyGetUpstreamHosts(&raw, &rvs)
+	st := internal.ProxyGetUpstreamHosts(unsafe.Pointer(&raw), &rvs)
 	if st != internal.StatusOK {
 		return nil, internal.StatusToError(st)
 	} else if raw == nil {
 		return nil, types.ErrorStatusNotFound
 	}
 
-	bs := internal.RawBytePtrToByteSlice(raw, rvs)
+	bs := unsafe.Slice(raw, rvs)
 	return internal.DeserializeMap(bs), nil
 }
 
@@ -205,7 +205,7 @@ func SetUpstreamOverrideHost(address []byte) error {
 	if len(address) > 0 {
 		addressPtr = &address[0]
 	}
-	switch st := internal.ProxySetUpstreamOverrideHost(addressPtr, len(address)); st {
+	switch st := internal.ProxySetUpstreamOverrideHost(addressPtr, int32(len(address))); st {
 	case internal.StatusOK:
 		return nil
 	default:

--- a/proxywasm/internal/abi_hostcalls.go
+++ b/proxywasm/internal/abi_hostcalls.go
@@ -81,6 +81,15 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int32, headerData *byte, hea
 //go:wasmimport env proxy_call_foreign_function
 func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *byte, paramSize int32, returnData unsafe.Pointer, returnSize *int32) Status
 
+//go:wasmimport env proxy_inject_encoded_data_to_filter_chain
+func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status
+
+//go:wasmimport env proxy_get_upstream_hosts
+func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status
+
+//go:wasmimport env proxy_set_upstream_override_host
+func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status
+
 //go:wasmimport env proxy_redis_init
 func ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32,
 	passwordData *byte, passwordSize int32, timeout uint32,

--- a/proxywasm/internal/abi_hostcalls.go
+++ b/proxywasm/internal/abi_hostcalls.go
@@ -82,13 +82,13 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int32, headerData *byte, hea
 func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *byte, paramSize int32, returnData unsafe.Pointer, returnSize *int32) Status
 
 //go:wasmimport env proxy_inject_encoded_data_to_filter_chain
-func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status
+func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) Status
 
 //go:wasmimport env proxy_get_upstream_hosts
-func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status
+func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int32) Status
 
 //go:wasmimport env proxy_set_upstream_override_host
-func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status
+func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) Status
 
 //go:wasmimport env proxy_redis_init
 func ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32,

--- a/proxywasm/internal/abi_hostcalls.go
+++ b/proxywasm/internal/abi_hostcalls.go
@@ -85,7 +85,7 @@ func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *b
 func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) Status
 
 //go:wasmimport env proxy_get_upstream_hosts
-func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int32) Status
+func ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, returnValueSize *int32) Status
 
 //go:wasmimport env proxy_set_upstream_override_host
 func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) Status

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -52,8 +52,6 @@ type ProxyWasmHost interface {
 	ProxyReplaceHeaderMapValue(mapType MapType, keyData *byte, keySize int32, valueData *byte, valueSize int32) Status
 	ProxyContinueStream(streamType StreamType) Status
 	ProxyCloseStream(streamType StreamType) Status
-<<<<<<< Updated upstream
-
 	ProxyRemoveHeaderMapValue(mapType MapType, keyData *byte, keySize int32) Status
 	ProxyGetHeaderMapPairs(mapType MapType, returnValueData unsafe.Pointer, returnValueSize *int32) Status
 	ProxySetHeaderMapPairs(mapType MapType, mapData *byte, mapSize int32) Status
@@ -63,20 +61,9 @@ type ProxyWasmHost interface {
 	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *byte, paramSize int32, returnData unsafe.Pointer, returnSize *int32) Status
 	ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32, passwordData *byte, passwordSize int32, timeout uint32) Status
 	ProxyRedisCall(upstreamData *byte, upstreamSize int32, queryData *byte, querySize int32, calloutIDPtr *uint32) Status
-=======
-	ProxyRemoveHeaderMapValue(mapType MapType, keyData *byte, keySize int) Status
-	ProxyGetHeaderMapPairs(mapType MapType, returnValueData **byte, returnValueSize *int) Status
-	ProxySetHeaderMapPairs(mapType MapType, mapData *byte, mapSize int) Status
-	ProxyGetBufferBytes(bufferType BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) Status
-	ProxySetBufferBytes(bufferType BufferType, start int, maxSize int, bufferData *byte, bufferSize int) Status
-	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) Status
-	ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status
-	ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status
-	ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status
-	ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int, passwordData *byte, passwordSize int, timeout uint32) Status
-	ProxyRedisCall(upstreamData *byte, upstreamSize int, queryData *byte, querySize int, calloutIDPtr *uint32) Status
-	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) Status
->>>>>>> Stashed changes
+	ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) Status
+	ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, returnValueSize *int32) Status
+	ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) Status
 	ProxySetTickPeriodMilliseconds(period uint32) Status
 	ProxySetEffectiveContext(contextID uint32) Status
 	ProxyDone() Status
@@ -172,21 +159,17 @@ func (d DefaultProxyWAMSHost) ProxyGetMetric(metricID uint32, returnMetricValue 
 	return 0
 }
 
-<<<<<<< Updated upstream
-func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int32) Status {
-=======
-func (d DefaultProxyWAMSHost) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status {
+func (d DefaultProxyWAMSHost) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) Status {
 	return 0
 }
-func (d DefaultProxyWAMSHost) ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status {
+func (d DefaultProxyWAMSHost) ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, returnValueSize *int32) Status {
 	return 0
 }
-func (d DefaultProxyWAMSHost) ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status {
+func (d DefaultProxyWAMSHost) ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) Status {
 	return 0
 }
 
-func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status {
->>>>>>> Stashed changes
+func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int32) Status {
 	return currentHost.ProxyLog(logLevel, messageData, messageSize)
 }
 

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -281,7 +281,7 @@ func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStre
 	return currentHost.ProxyInjectEncodedDataToFilterChain(bodyData, bodySize, endStream)
 }
 
-func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int32) Status {
+func ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, returnValueSize *int32) Status {
 	return currentHost.ProxyGetUpstreamHosts(returnValueData, returnValueSize)
 }
 

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -277,15 +277,15 @@ func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *b
 	return currentHost.ProxyCallForeignFunction(funcNamePtr, funcNameSize, paramPtr, paramSize, returnData, returnSize)
 }
 
-func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status {
+func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) Status {
 	return currentHost.ProxyInjectEncodedDataToFilterChain(bodyData, bodySize, endStream)
 }
 
-func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status {
+func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int32) Status {
 	return currentHost.ProxyGetUpstreamHosts(returnValueData, returnValueSize)
 }
 
-func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status {
+func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) Status {
 	return currentHost.ProxySetUpstreamOverrideHost(bodyData, bodySize)
 }
 

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -52,6 +52,7 @@ type ProxyWasmHost interface {
 	ProxyReplaceHeaderMapValue(mapType MapType, keyData *byte, keySize int32, valueData *byte, valueSize int32) Status
 	ProxyContinueStream(streamType StreamType) Status
 	ProxyCloseStream(streamType StreamType) Status
+<<<<<<< Updated upstream
 
 	ProxyRemoveHeaderMapValue(mapType MapType, keyData *byte, keySize int32) Status
 	ProxyGetHeaderMapPairs(mapType MapType, returnValueData unsafe.Pointer, returnValueSize *int32) Status
@@ -62,6 +63,20 @@ type ProxyWasmHost interface {
 	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *byte, paramSize int32, returnData unsafe.Pointer, returnSize *int32) Status
 	ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32, passwordData *byte, passwordSize int32, timeout uint32) Status
 	ProxyRedisCall(upstreamData *byte, upstreamSize int32, queryData *byte, querySize int32, calloutIDPtr *uint32) Status
+=======
+	ProxyRemoveHeaderMapValue(mapType MapType, keyData *byte, keySize int) Status
+	ProxyGetHeaderMapPairs(mapType MapType, returnValueData **byte, returnValueSize *int) Status
+	ProxySetHeaderMapPairs(mapType MapType, mapData *byte, mapSize int) Status
+	ProxyGetBufferBytes(bufferType BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) Status
+	ProxySetBufferBytes(bufferType BufferType, start int, maxSize int, bufferData *byte, bufferSize int) Status
+	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) Status
+	ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status
+	ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status
+	ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status
+	ProxyRedisInit(upstreamData *byte, upstreamSize int, usernameData *byte, usernameSize int, passwordData *byte, passwordSize int, timeout uint32) Status
+	ProxyRedisCall(upstreamData *byte, upstreamSize int, queryData *byte, querySize int, calloutIDPtr *uint32) Status
+	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) Status
+>>>>>>> Stashed changes
 	ProxySetTickPeriodMilliseconds(period uint32) Status
 	ProxySetEffectiveContext(contextID uint32) Status
 	ProxyDone() Status
@@ -157,7 +172,21 @@ func (d DefaultProxyWAMSHost) ProxyGetMetric(metricID uint32, returnMetricValue 
 	return 0
 }
 
+<<<<<<< Updated upstream
 func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int32) Status {
+=======
+func (d DefaultProxyWAMSHost) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status {
+	return 0
+}
+
+func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status {
+>>>>>>> Stashed changes
 	return currentHost.ProxyLog(logLevel, messageData, messageSize)
 }
 
@@ -246,6 +275,18 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int32, headerData *byte, hea
 
 func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, paramPtr *byte, paramSize int32, returnData unsafe.Pointer, returnSize *int32) Status {
 	return currentHost.ProxyCallForeignFunction(funcNamePtr, funcNameSize, paramPtr, paramSize, returnData, returnSize)
+}
+
+func ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int, endStream bool) Status {
+	return currentHost.ProxyInjectEncodedDataToFilterChain(bodyData, bodySize, endStream)
+}
+
+func ProxyGetUpstreamHosts(returnValueData **byte, returnValueSize *int) Status {
+	return currentHost.ProxyGetUpstreamHosts(returnValueData, returnValueSize)
+}
+
+func ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int) Status {
+	return currentHost.ProxySetUpstreamOverrideHost(bodyData, bodySize)
 }
 
 func ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32,


### PR DESCRIPTION
support interface following:
- `InjectEncodedDataToFilterChain`
- `GetUpstreamHosts`
- `SetUpstreamOverrideHost`