### PR TITLE
fix: update proxytest unit framework to support wasm-go wrapper

### DIFF
--- a/proxywasm/entrypoint.go
+++ b/proxywasm/entrypoint.go
@@ -28,6 +28,16 @@ func SetVMContext(ctx types.VMContext) {
 	internal.SetVMContext(ctx)
 }
 
+// GetVMContext is used to get VMContext in wasm-go unit test framework
+func GetVMContext() types.VMContext {
+	return internal.GetVMContext()
+}
+
+// GetHttpContext is used to get HttpContext in wasm-go unit test framework
+func GetHttpContext(contextID uint32) types.HttpContext {
+	return internal.GetHttpContext(contextID)
+}
+
 // SetPluginContext is one possible entrypoint for setting up the Wasm VM.
 //
 // Subsequent calls to any entrypoint overwrite previous calls to any

--- a/proxywasm/internal/abi_callback_test_export.go
+++ b/proxywasm/internal/abi_callback_test_export.go
@@ -76,6 +76,10 @@ func ProxyOnHttpCallResponse(pluginContextID, calloutID uint32, numHeaders, body
 	proxyOnHttpCallResponse(pluginContextID, calloutID, numHeaders, bodySize, numTrailers)
 }
 
+func ProxyOnRedisCallResponse(pluginContextID, calloutID uint32, status, responseSize int32) {
+	proxyOnRedisCallResponse(pluginContextID, calloutID, status, responseSize)
+}
+
 func ProxyOnContextCreate(contextID uint32, pluginContextID uint32) {
 	proxyOnContextCreate(contextID, pluginContextID)
 }

--- a/proxywasm/internal/vmstate.go
+++ b/proxywasm/internal/vmstate.go
@@ -57,6 +57,16 @@ func SetVMContext(vmContext types.VMContext) {
 	currentState.vmContext = vmContext
 }
 
+// GetVMContext is used to get VMContext in wasm-go unit test framework
+func GetVMContext() types.VMContext {
+	return currentState.vmContext
+}
+
+// GetHttpContext is used to get HttpContext in wasm-go unit test framework
+func GetHttpContext(contextID uint32) types.HttpContext {
+	return currentState.httpContexts[contextID]
+}
+
 func RegisterHttpCallout(calloutID uint32, callback func(numHeaders, bodySize, numTrailers int)) {
 	currentState.registerHttpCallOut(calloutID, callback)
 }

--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -309,19 +309,19 @@ func (h *httpHostEmulator) httpHostEmulatorProxyGetHeaderMapPairs(mapType intern
 
 // impl internal.ProxyWasmHost
 func (h *httpHostEmulator) ProxySetHeaderMapPairs(mapType internal.MapType, mapData *byte, mapSize int32) internal.Status {
-	m := deserializeRawBytePtrToMap(mapData, mapSize)
+	m := cloneWithLowerCaseMapKeys(deserializeRawBytePtrToMap(mapData, mapSize))
 	active := internal.VMStateGetActiveContextID()
 	stream := h.httpStreams[active]
 
 	switch mapType {
 	case internal.MapTypeHttpRequestHeaders:
-		stream.requestHeaders = cloneWithLowerCaseMapKeys(m)
+		stream.requestHeaders = m
 	case internal.MapTypeHttpResponseHeaders:
-		stream.responseHeaders = cloneWithLowerCaseMapKeys(m)
+		stream.responseHeaders = m
 	case internal.MapTypeHttpRequestTrailers:
-		stream.requestTrailers = cloneWithLowerCaseMapKeys(m)
+		stream.requestTrailers = m
 	case internal.MapTypeHttpResponseTrailers:
-		stream.responseTrailers = cloneWithLowerCaseMapKeys(m)
+		stream.responseTrailers = m
 	default:
 		panic("unimplemented")
 	}

--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -315,13 +315,13 @@ func (h *httpHostEmulator) ProxySetHeaderMapPairs(mapType internal.MapType, mapD
 
 	switch mapType {
 	case internal.MapTypeHttpRequestHeaders:
-		stream.requestHeaders = m
+		stream.requestHeaders = cloneWithLowerCaseMapKeys(m)
 	case internal.MapTypeHttpResponseHeaders:
-		stream.responseHeaders = m
+		stream.responseHeaders = cloneWithLowerCaseMapKeys(m)
 	case internal.MapTypeHttpRequestTrailers:
-		stream.requestTrailers = m
+		stream.requestTrailers = cloneWithLowerCaseMapKeys(m)
 	case internal.MapTypeHttpResponseTrailers:
-		stream.responseTrailers = m
+		stream.responseTrailers = cloneWithLowerCaseMapKeys(m)
 	default:
 		panic("unimplemented")
 	}

--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -544,3 +544,12 @@ func (h *httpHostEmulator) SetProperty(path []string, data []byte) error {
 		&raw[0], int32(len(raw)), &data[0], int32(len(data)),
 	))
 }
+
+// impl HostEmulator
+func (h *httpHostEmulator) SetHttpRequestHeaders(contextID uint32, headers [][2]string) {
+	cs, ok := h.httpStreams[contextID]
+	if !ok {
+		log.Fatalf("invalid context id: %d", contextID)
+	}
+	cs.requestHeaders = cloneWithLowerCaseMapKeys(headers)
+}

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -40,6 +40,10 @@ type HostEmulator interface {
 	GetCalloutAttributesFromContext(contextID uint32) []HttpCalloutAttribute
 	// CallOnHttpCallResponse executes the callback for the HTTP call with ID calloutID in the plugin.
 	CallOnHttpCallResponse(calloutID uint32, headers [][2]string, trailers [][2]string, body []byte)
+	// GetRedisCalloutAttributesFromContext returns the current Redis callout attributes for the given context in the host.
+	GetRedisCalloutAttributesFromContext(contextID uint32) []RedisCalloutAttribute
+	// CallOnRedisCallResponse executes the callback for the Redis call with ID calloutID in the plugin.
+	CallOnRedisCallResponse(calloutID uint32, status int32, response []byte)
 	// GetCounterMetric returns the value for the counter in the host.
 	GetCounterMetric(name string) (uint64, error)
 	// GetGaugeMetric returns the value for the gauge in the host.
@@ -329,18 +333,6 @@ func (h *hostEmulator) ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, ret
 // impl internal.ProxyWasmHost
 func (h *hostEmulator) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) internal.Status {
 	log.Printf("ProxyInjectEncodedDataToFilterChain not implemented in the host emulator yet")
-	return 0
-}
-
-// impl internal.ProxyWasmHost
-func (h *hostEmulator) ProxyRedisCall(upstreamData *byte, upstreamSize int32, queryData *byte, querySize int32, calloutIDPtr *uint32) internal.Status {
-	log.Printf("ProxyRedisCall not implemented in the host emulator yet")
-	return 0
-}
-
-// impl internal.ProxyWasmHost
-func (h *hostEmulator) ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32, passwordData *byte, passwordSize int32, timeout uint32) internal.Status {
-	log.Printf("ProxyRedisInit not implemented in the host emulator yet")
 	return 0
 }
 

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -317,3 +317,33 @@ func (h *hostEmulator) ProxyDone() internal.Status {
 	log.Printf("ProxyDone not implemented in the host emulator yet")
 	return 0
 }
+
+// impl internal.ProxyWasmHost
+func (h *hostEmulator) ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, returnValueSize *int32) internal.Status {
+	log.Printf("ProxyGetUpstreamHosts not implemented in the host emulator yet")
+	return 0
+}
+
+// impl internal.ProxyWasmHost
+func (h *hostEmulator) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) internal.Status {
+	log.Printf("ProxyInjectEncodedDataToFilterChain not implemented in the host emulator yet")
+	return 0
+}
+
+// impl internal.ProxyWasmHost
+func (h *hostEmulator) ProxyRedisCall(upstreamData *byte, upstreamSize int32, queryData *byte, querySize int32, calloutIDPtr *uint32) internal.Status {
+	log.Printf("ProxyRedisCall not implemented in the host emulator yet")
+	return 0
+}
+
+// impl internal.ProxyWasmHost
+func (h *hostEmulator) ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32, passwordData *byte, passwordSize int32, timeout uint32) internal.Status {
+	log.Printf("ProxyRedisInit not implemented in the host emulator yet")
+	return 0
+}
+
+// impl internal.ProxyWasmHost
+func (h *hostEmulator) ProxySetUpstreamOverrideHost(bodyData *byte, bodySize int32) internal.Status {
+	log.Printf("ProxySetUpstreamOverrideHost not implemented in the host emulator yet")
+	return 0
+}

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -131,6 +131,8 @@ type HostEmulator interface {
 	GetProperty(path []string) ([]byte, error)
 	// SetProperty sets property data on the host, for a given path.
 	SetProperty(path []string, data []byte) error
+	// SetHttpRequestHeader sets the request header for the HTTP stream with ID contextID in the host.
+	SetHttpRequestHeaders(contextID uint32, headers [][2]string)
 }
 
 const (

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -224,7 +224,7 @@ func getNextContextID() (ret uint32) {
 func (h *hostEmulator) ProxyGetBufferBytes(bt internal.BufferType, start int32, maxSize int32,
 	returnBufferData unsafe.Pointer, returnBufferSize *int32) internal.Status {
 	switch bt {
-	case internal.BufferTypePluginConfiguration, internal.BufferTypeVMConfiguration, internal.BufferTypeHttpCallResponseBody:
+	case internal.BufferTypePluginConfiguration, internal.BufferTypeVMConfiguration, internal.BufferTypeHttpCallResponseBody, internal.BufferTypeRedisCallResponse:
 		return h.rootHostEmulatorProxyGetBufferBytes(bt, start, maxSize, returnBufferData, returnBufferSize)
 	case internal.BufferTypeDownstreamData, internal.BufferTypeUpstreamData:
 		return h.networkHostEmulatorProxyGetBufferBytes(bt, start, maxSize, returnBufferData, returnBufferSize)

--- a/proxywasm/proxytest/root.go
+++ b/proxywasm/proxytest/root.go
@@ -55,6 +55,10 @@ type (
 		metricIDToValue map[uint32]uint64
 
 		pluginConfiguration, vmConfiguration []byte
+
+		// Add unique ID counters
+		nextHttpCalloutID  uint32
+		nextRedisCalloutID uint32
 	}
 
 	HttpCalloutAttribute struct {
@@ -273,7 +277,8 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int32,
 	log.Printf("[http callout to %s] body: %s", upstream, body)
 	log.Printf("[http callout to %s] trailers: %v", upstream, trailers)
 
-	calloutID := uint32(len(r.httpCalloutIDToContextID))
+	calloutID := r.nextHttpCalloutID
+	r.nextHttpCalloutID++
 	contextID := internal.VMStateGetActiveContextID()
 	r.httpCalloutIDToContextID[calloutID] = contextID
 	r.httpContextIDToCalloutInfos[contextID] = append(r.httpContextIDToCalloutInfos[contextID], HttpCalloutAttribute{
@@ -295,7 +300,8 @@ func (r *rootHostEmulator) ProxyRedisCall(upstreamData *byte, upstreamSize int32
 
 	log.Printf("[redis callout to %s] query: %v", upstream, query)
 
-	calloutID := uint32(len(r.redisCalloutIDToContextID))
+	calloutID := r.nextRedisCalloutID
+	r.nextRedisCalloutID++
 	contextID := internal.VMStateGetActiveContextID()
 	r.redisCalloutIDToContextID[calloutID] = contextID
 	r.redisContextIDToCalloutInfos[contextID] = append(r.redisContextIDToCalloutInfos[contextID], RedisCalloutAttribute{

--- a/proxywasm/proxytest/root.go
+++ b/proxywasm/proxytest/root.go
@@ -43,6 +43,13 @@ type (
 			body     []byte
 		}
 
+		redisContextIDToCalloutInfos map[uint32][]RedisCalloutAttribute // key: contextID
+		redisCalloutIDToContextID    map[uint32]uint32                  // key: calloutID
+		redisCalloutResponse         map[uint32]struct {                // key: calloutID
+			status   int32
+			response []byte
+		}
+
 		metricIDToType  map[uint32]internal.MetricType
 		metricNameToID  map[string]uint32
 		metricIDToValue map[uint32]uint64
@@ -56,6 +63,12 @@ type (
 		Headers   [][2]string
 		Trailers  [][2]string
 		Body      []byte
+	}
+
+	RedisCalloutAttribute struct {
+		CalloutID uint32
+		Upstream  string
+		Query     []byte
 	}
 
 	sharedData struct {
@@ -79,6 +92,13 @@ func newRootHostEmulator(pluginConfiguration, vmConfiguration []byte) *rootHostE
 			headers  [][2]string
 			trailers [][2]string
 			body     []byte
+		}{},
+
+		redisContextIDToCalloutInfos: map[uint32][]RedisCalloutAttribute{},
+		redisCalloutIDToContextID:    map[uint32]uint32{},
+		redisCalloutResponse: map[uint32]struct {
+			status   int32
+			response []byte
 		}{},
 
 		pluginConfiguration: pluginConfiguration,
@@ -269,6 +289,38 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int32,
 }
 
 // impl internal.ProxyWasmHost
+func (r *rootHostEmulator) ProxyRedisCall(upstreamData *byte, upstreamSize int32, queryData *byte, querySize int32, calloutIDPtr *uint32) internal.Status {
+	upstream := unsafe.String(upstreamData, upstreamSize)
+	query := unsafe.Slice(queryData, querySize)
+
+	log.Printf("[redis callout to %s] query: %v", upstream, query)
+
+	calloutID := uint32(len(r.redisCalloutIDToContextID))
+	contextID := internal.VMStateGetActiveContextID()
+	r.redisCalloutIDToContextID[calloutID] = contextID
+	r.redisContextIDToCalloutInfos[contextID] = append(r.redisContextIDToCalloutInfos[contextID], RedisCalloutAttribute{
+		CalloutID: calloutID,
+		Upstream:  upstream,
+		Query:     query,
+	})
+
+	*calloutIDPtr = calloutID
+	return internal.StatusOK
+}
+
+// impl internal.ProxyWasmHost
+func (r *rootHostEmulator) ProxyRedisInit(upstreamData *byte, upstreamSize int32, usernameData *byte, usernameSize int32, passwordData *byte, passwordSize int32, timeout uint32) internal.Status {
+	upstream := unsafe.String(upstreamData, upstreamSize)
+	username := unsafe.String(usernameData, usernameSize)
+	password := unsafe.String(passwordData, passwordSize)
+
+	log.Printf("[redis init] upstream: %s, username: %s, timeout: %d", upstream, username, timeout)
+	log.Printf("[redis init] password: %s", password)
+
+	return internal.StatusOK
+}
+
+// impl internal.ProxyWasmHost
 func (r *rootHostEmulator) RegisterForeignFunction(name string, f func([]byte) []byte) {
 	r.foreignFunctions[name] = f
 }
@@ -362,6 +414,12 @@ func (r *rootHostEmulator) rootHostEmulatorProxyGetBufferBytes(bt internal.Buffe
 			log.Fatalf("callout response unregistered for %d", activeID)
 		}
 		buf = res.body
+	case internal.BufferTypeRedisCallResponse:
+		res, ok := r.redisCalloutResponse[r.activeCalloutID]
+		if !ok {
+			log.Fatalf("redis callout response unregistered for %d", r.activeCalloutID)
+		}
+		buf = res.response
 	default:
 		panic("unreachable: maybe a bug in this host emulation or SDK")
 	}
@@ -439,6 +497,12 @@ func (r *rootHostEmulator) GetCalloutAttributesFromContext(contextID uint32) []H
 }
 
 // impl HostEmulator
+func (r *rootHostEmulator) GetRedisCalloutAttributesFromContext(contextID uint32) []RedisCalloutAttribute {
+	infos := r.redisContextIDToCalloutInfos[contextID]
+	return infos
+}
+
+// impl HostEmulator
 func (r *rootHostEmulator) StartVM() types.OnVMStartStatus {
 	return internal.ProxyOnVMStart(PluginContextID, int32(len(r.vmConfiguration)))
 }
@@ -463,6 +527,23 @@ func (r *rootHostEmulator) CallOnHttpCallResponse(calloutID uint32, headers, tra
 		delete(r.httpCalloutIDToContextID, calloutID)
 	}()
 	internal.ProxyOnHttpCallResponse(PluginContextID, calloutID, int32(len(headers)), int32(len(body)), int32(len(trailers)))
+}
+
+// impl HostEmulator
+func (r *rootHostEmulator) CallOnRedisCallResponse(calloutID uint32, status int32, response []byte) {
+	r.redisCalloutResponse[calloutID] = struct {
+		status   int32
+		response []byte
+	}{status: status, response: response}
+
+	// PluginContextID, calloutID uint32, status, responseSize in
+	r.activeCalloutID = calloutID
+	defer func() {
+		r.activeCalloutID = 0
+		delete(r.redisCalloutResponse, calloutID)
+		delete(r.redisCalloutIDToContextID, calloutID)
+	}()
+	internal.ProxyOnRedisCallResponse(PluginContextID, calloutID, status, int32(len(response)))
 }
 
 // impl HostEmulator

--- a/proxywasm/proxytest/root.go
+++ b/proxywasm/proxytest/root.go
@@ -524,7 +524,22 @@ func (r *rootHostEmulator) CallOnHttpCallResponse(calloutID uint32, headers, tra
 	defer func() {
 		r.activeCalloutID = 0
 		delete(r.httpCalloutResponse, calloutID)
-		delete(r.httpCalloutIDToContextID, calloutID)
+
+		// Clean up contextID to callout mapping
+		if contextID, exists := r.httpCalloutIDToContextID[calloutID]; exists {
+			delete(r.httpCalloutIDToContextID, calloutID)
+
+			// Remove the corresponding entry from contextID's callout list
+			if callouts, exists := r.httpContextIDToCalloutInfos[contextID]; exists {
+				for i, callout := range callouts {
+					if callout.CalloutID == calloutID {
+						// Remove the i-th element
+						r.httpContextIDToCalloutInfos[contextID] = append(callouts[:i], callouts[i+1:]...)
+						break
+					}
+				}
+			}
+		}
 	}()
 	internal.ProxyOnHttpCallResponse(PluginContextID, calloutID, int32(len(headers)), int32(len(body)), int32(len(trailers)))
 }
@@ -541,7 +556,22 @@ func (r *rootHostEmulator) CallOnRedisCallResponse(calloutID uint32, status int3
 	defer func() {
 		r.activeCalloutID = 0
 		delete(r.redisCalloutResponse, calloutID)
-		delete(r.redisCalloutIDToContextID, calloutID)
+
+		// Clean up contextID to callout mapping
+		if contextID, exists := r.redisCalloutIDToContextID[calloutID]; exists {
+			delete(r.redisCalloutIDToContextID, calloutID)
+
+			// Remove the corresponding entry from contextID's callout list
+			if callouts, exists := r.redisContextIDToCalloutInfos[contextID]; exists {
+				for i, callout := range callouts {
+					if callout.CalloutID == calloutID {
+						// Remove the i-th element
+						r.redisContextIDToCalloutInfos[contextID] = append(callouts[:i], callouts[i+1:]...)
+						break
+					}
+				}
+			}
+		}
 	}()
 	internal.ProxyOnRedisCallResponse(PluginContextID, calloutID, status, int32(len(response)))
 }

--- a/proxywasm/proxytest/wasmwrapper.go
+++ b/proxywasm/proxytest/wasmwrapper.go
@@ -618,6 +618,40 @@ func exportHostABI(ctx context.Context, r wazero.Runtime) error {
 			return ret
 		}).
 		Export("proxy_http_call").
+		// proxy_redis_init initializes a Redis connection.
+		NewFunctionBuilder().
+		WithParameterNames("upstream_data", "upstream_size", "username_data", "username_size", "password_data", "password_size", "timeout").
+		WithResultNames("call_result").
+		WithFunc(func(ctx context.Context, mod api.Module, upstreamData, upstreamSize, usernameData, usernameSize, passwordData, passwordSize, timeout uint32) uint32 {
+			upstreamPtr := wasmBytePtr(mod, upstreamData, upstreamSize)
+			usernamePtr := wasmBytePtr(mod, usernameData, usernameSize)
+			passwordPtr := wasmBytePtr(mod, passwordData, passwordSize)
+			return uint32(internal.ProxyRedisInit(upstreamPtr, int32(upstreamSize), usernamePtr, int32(usernameSize), passwordPtr, int32(passwordSize), timeout))
+		}).
+		Export("proxy_redis_init").
+		// proxy_redis_call dispatches a Redis call to upstream.
+		NewFunctionBuilder().
+		WithParameterNames("upstream_data", "upstream_size", "query_data", "query_size", "return_callout_id").
+		WithResultNames("call_result").
+		WithFunc(func(ctx context.Context, mod api.Module, upstreamData, upstreamSize, queryData, querySize, calloutIDPtr uint32) uint32 {
+			upstreamPtr := wasmBytePtr(mod, upstreamData, upstreamSize)
+			queryPtr := wasmBytePtr(mod, queryData, querySize)
+			var calloutID uint32
+			ret := uint32(internal.ProxyRedisCall(upstreamPtr, int32(upstreamSize), queryPtr, int32(querySize), &calloutID))
+			handleMemoryStatus(mod.Memory().WriteUint32Le(calloutIDPtr, calloutID))
+
+			// Register Redis callback
+			internal.RegisterRedisCallout(calloutID, func(status, responseSize int) {
+				proxyOnRedisCallResponse := mod.ExportedFunction("proxy_on_redis_call_response")
+				_, err := proxyOnRedisCallResponse.Call(ctx, uint64(getPluginContextID(ctx)), uint64(calloutID), uint64(status), uint64(responseSize))
+				if err != nil {
+					panic(err)
+				}
+			})
+
+			return ret
+		}).
+		Export("proxy_redis_call").
 		// proxy_call_foreign_function calls a registered foreign function.
 		//
 		// See https://github.com/proxy-wasm/spec/tree/master/abi-versions/vNEXT#proxy_call_foreign_function


### PR DESCRIPTION
1. expose GetVMContext() interface for wasm-go to get VM Context.
2. expose GetHttpContext interface for wasm-go to get HTTP Context.
3. add SetHttpRequestHeaders function for GetMatchConfig in wasm-go to test parseConfig function in wasm plugin
4. support redis call mock 