### PR TITLE
feat: implement ProxyInjectEncodedDataToFilterChain for test framework

### DIFF
--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -40,6 +40,13 @@ type (
 		// content of body is sent to the upstream or downstream.
 		requestBody, responseBody []byte
 
+		// injectedResponseData stores data injected by ProxyInjectEncodedDataToFilterChain
+		// This is used for SSE streaming responses and other scenarios where the plugin
+		// needs to inject custom response data
+		injectedResponseData []byte
+		// hasInjectedData indicates whether response data has been injected
+		hasInjectedData bool
+
 		action            types.Action
 		sentLocalResponse *LocalHttpResponse
 	}
@@ -495,6 +502,14 @@ func (h *httpHostEmulator) GetCurrentResponseBody(contextID uint32) []byte {
 	if !ok {
 		log.Fatalf("invalid context id: %d", contextID)
 	}
+	// If data was injected via ProxyInjectEncodedDataToFilterChain, return that instead
+	// TODO: This is a simplified implementation. In most use cases, InjectEncodedData is used
+	// to bypass the original response body stream and fully control the body content.
+	// Future enhancements may need to support scenarios where partial response body has already
+	// been sent before injecting data (e.g., appending injected data to existing response body).
+	if stream.hasInjectedData {
+		return stream.injectedResponseData
+	}
 	return stream.responseBody
 }
 
@@ -552,4 +567,30 @@ func (h *httpHostEmulator) SetHttpRequestHeaders(contextID uint32, headers [][2]
 		log.Fatalf("invalid context id: %d", contextID)
 	}
 	cs.requestHeaders = cloneWithLowerCaseMapKeys(headers)
+}
+
+// impl internal.ProxyWasmHost
+func (h *httpHostEmulator) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) internal.Status {
+	active := internal.VMStateGetActiveContextID()
+	stream, ok := h.httpStreams[active]
+	if !ok {
+		log.Fatalf("invalid context id: %d", active)
+	}
+
+	// Copy the injected data to the stream's injectedResponseData
+	if bodySize > 0 && bodyData != nil {
+		data := unsafe.Slice(bodyData, bodySize)
+		// If this is a fresh injection, reset the buffer
+		if !stream.hasInjectedData {
+			stream.injectedResponseData = nil
+		}
+		stream.injectedResponseData = append(stream.injectedResponseData, data...)
+	}
+
+	// If endStream is true, mark that we have injected data
+	if endStream {
+		stream.hasInjectedData = true
+	}
+
+	return internal.StatusOK
 }

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -332,8 +332,7 @@ func (h *hostEmulator) ProxyGetUpstreamHosts(returnValueData unsafe.Pointer, ret
 
 // impl internal.ProxyWasmHost
 func (h *hostEmulator) ProxyInjectEncodedDataToFilterChain(bodyData *byte, bodySize int32, endStream bool) internal.Status {
-	log.Printf("ProxyInjectEncodedDataToFilterChain not implemented in the host emulator yet")
-	return 0
+	return h.httpHostEmulator.ProxyInjectEncodedDataToFilterChain(bodyData, bodySize, endStream)
 }
 
 // impl internal.ProxyWasmHost


### PR DESCRIPTION
- Add injectedResponseData field to httpStreamState to store injected data
- Implement ProxyInjectEncodedDataToFilterChain in httpHostEmulator
- When endStream is true, replace response body with injected data
- Delegate implementation from hostEmulator to httpHostEmulator
- This enables testing of SSE streaming responses and custom response injection

Change-Id: I5f7bca6623c4678088e46ec046e53e18a2ca4620
Co-developed-by: Cursor <noreply@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements response data injection in the HTTP host emulator and delegates `ProxyInjectEncodedDataToFilterChain` from the root host to the HTTP emulator.
> 
> - **proxytest HTTP host emulator**
>   - Add `injectedResponseData` and `hasInjectedData` to `httpStreamState` for injected response bytes.
>   - Implement `ProxyInjectEncodedDataToFilterChain(...)` in `httpHostEmulator`; accumulates injected data and marks completion via `endStream`.
>   - Update `GetCurrentResponseBody(...)` to return `injectedResponseData` when present.
> - **host emulator**
>   - Delegate `ProxyInjectEncodedDataToFilterChain(...)` to `httpHostEmulator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5f31cbc6d0da21a135922099fb1f599069bcffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->