### PR TITLE
fix(proxytest): expose host wall/monotonic clock to wasm guest

### DIFF
--- a/proxywasm/proxytest/wasmwrapper.go
+++ b/proxywasm/proxytest/wasmwrapper.go
@@ -100,10 +100,18 @@ func NewWasmVMContext(wasm []byte) (WasmVMContext, error) {
 		return nil, err
 	}
 
+	// Expose the host wall clock and monotonic clock to the wasm guest so that
+	// time.Now() (which goes through WASI clock_time_get when compiled to wasm)
+	// returns real time. Without these, wazero's default clocks return epoch
+	// (1970-01-01) for walltime and 0 for nanotime, which breaks any plugin
+	// logic that compares timestamps to "now" — e.g. clock-skew validation in
+	// hmac-auth, JWT exp/nbf checks, request-deadline computations.
 	wazeroconfig := wazero.NewModuleConfig().
 		WithStartFunctions("_initialize", "_start", "main").
 		WithStdout(os.Stderr).
-		WithStderr(os.Stderr)
+		WithStderr(os.Stderr).
+		WithSysWalltime().
+		WithSysNanotime()
 	mod, err := r.InstantiateModule(ctx, compiled, wazeroconfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Background

`NewWasmVMContext` builds the wazero `ModuleConfig` with only `WithStartFunctions` / `WithStdout` / `WithStderr` — it never calls `WithSysWalltime()` or `WithSysNanotime()`.

By [wazero's default](https://github.com/tetratelabs/wazero/blob/main/config.go), this means:

- `clock_time_get(CLOCK_REALTIME, ...)` inside the guest returns **epoch (1970-01-01)**
- `clock_time_get(CLOCK_MONOTONIC, ...)` returns **0**

Any Go plugin compiled with `GOOS=wasip1 GOARCH=wasm` whose runtime logic compares against `time.Now()` therefore sees a 56-year drift from the host clock when running under proxytest, even though the same code is correct in go-mode tests and in production (where Envoy / MOSN expose real time via host ABI).

## Reproducer

While building wasm-mode tests for higress `hmac-auth-apisix`, a plain "Date header is a few seconds old, well within `clock_skew=300`" case fails on the wasm arm only:

```
=== RUN   TestClockSkew_WithinTolerance_Succeeds/wasm
    Error: Expected nil, but got: ...
    Data: {"message":"client request can't be validated: Clock skew exceeded"}
--- FAIL: TestClockSkew_WithinTolerance_Succeeds/wasm
```

Same input passes `/go`. The plugin's `validateClockSkew` calls `time.Now()` → gets 1970 → diff against the 2026-dated header is ~56 years → trips `clock_skew`. The plugin is correct; the test framework's clock is the problem.

The same trap silently miscompares for any plugin that touches `time.Now()`:

- JWT `exp` / `nbf` claim verification (everything is "expired since 1970" or "not valid until far future")
- Request-deadline / retry-budget math
- Rate-limit window calculations
- Cache TTL eviction tied to wall time

These cases either pass for the wrong reason (e.g. "stale date rejected" is rejected because diff is 56 years, not because the plugin's logic worked) or they fail spuriously like the one above.

## Fix

Chain `WithSysWalltime()` and `WithSysNanotime()` onto the existing `ModuleConfig`. wazero then delegates to `time.Now()` / `time.Now().UnixNano()` on the host, which is exactly what a real proxy host does for wasm filters. No new dependencies, no runtime cost.

## Verification

With this patch applied locally (via `replace` directive in higress) the same hmac-auth-apisix test passes both arms:

```
--- PASS: TestClockSkew_WithinTolerance_Succeeds (22.49s)
    --- PASS: TestClockSkew_WithinTolerance_Succeeds/go (0.00s)
    --- PASS: TestClockSkew_WithinTolerance_Succeeds/wasm (22.49s)
```

Full hmac-auth-apisix suite: `91.7%` coverage, both modes green.

Existing proxytest go-mode tests and any wasm tests that didn't depend on wall time are unaffected.