### PR TITLE
fix: skip disabled debug log formatting

### DIFF
--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -15,6 +15,7 @@
 package proxywasm
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -752,8 +753,20 @@ func LogDebug(msg string) {
 // https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
 // information.
 func LogDebugf(format string, args ...interface{}) {
+	if !isLogLevelEnabled(internal.LogLevelDebug) {
+		return
+	}
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), int32(len(msg)))
+}
+
+func isLogLevelEnabled(level internal.LogLevel) bool {
+	value, err := CallForeignFunction("get_log_level", nil)
+	if err != nil || len(value) < 4 {
+		// Preserve compatibility with hosts that do not provide get_log_level.
+		return true
+	}
+	return level >= internal.LogLevel(binary.LittleEndian.Uint32(value))
 }
 
 // LogInfo emits a message as a log with Info log level.

--- a/proxywasm/hostcall_test.go
+++ b/proxywasm/hostcall_test.go
@@ -15,6 +15,7 @@
 package proxywasm
 
 import (
+	"encoding/binary"
 	"testing"
 	"unsafe"
 
@@ -27,6 +28,41 @@ type logHost struct {
 	t           *testing.T
 	expMessage  string
 	expLogLevel internal.LogLevel
+}
+
+type logLevelHost struct {
+	internal.DefaultProxyWAMSHost
+	levelData [4]byte
+	logCalls  int
+}
+
+func newLogLevelHost(level internal.LogLevel) *logLevelHost {
+	host := &logLevelHost{}
+	binary.LittleEndian.PutUint32(host.levelData[:], uint32(level))
+	return host
+}
+
+func (l *logLevelHost) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int32, _ *byte, _ int32, returnData unsafe.Pointer, returnSize *int32) internal.Status {
+	if unsafe.String(funcNamePtr, funcNameSize) != "get_log_level" {
+		return internal.StatusBadArgument
+	}
+	*(*unsafe.Pointer)(returnData) = unsafe.Pointer(&l.levelData[0])
+	*returnSize = int32(len(l.levelData))
+	return internal.StatusOK
+}
+
+func (l *logLevelHost) ProxyLog(_ internal.LogLevel, _ *byte, _ int32) internal.Status {
+	l.logCalls++
+	return internal.StatusOK
+}
+
+type countingStringer struct {
+	calls *int
+}
+
+func (s countingStringer) String() string {
+	*s.calls++
+	return "large response body"
 }
 
 func (l logHost) ProxyLog(logLevel internal.LogLevel, messageData *byte, messageSize int32) internal.Status {
@@ -176,6 +212,30 @@ func TestHostCall_Logging(t *testing.T) {
 		defer release()
 		LogCriticalf("critical: %s: %d", "log", 10)
 	})
+}
+
+func TestLogDebugfSkipsFormattingWhenDebugDisabled(t *testing.T) {
+	host := newLogLevelHost(internal.LogLevelInfo)
+	release := internal.RegisterMockWasmHost(host)
+	defer release()
+
+	formatCalls := 0
+	LogDebugf("response body: %s", countingStringer{calls: &formatCalls})
+
+	require.Equal(t, 0, formatCalls)
+	require.Equal(t, 0, host.logCalls)
+}
+
+func TestLogDebugfFormatsWhenDebugEnabled(t *testing.T) {
+	host := newLogLevelHost(internal.LogLevelDebug)
+	release := internal.RegisterMockWasmHost(host)
+	defer release()
+
+	formatCalls := 0
+	LogDebugf("response body: %s", countingStringer{calls: &formatCalls})
+
+	require.Equal(t, 1, formatCalls)
+	require.Equal(t, 1, host.logCalls)
 }
 
 type metricProxyWasmHost struct {


### PR DESCRIPTION
## Summary

- query the Higress host log level before formatting `LogDebugf` arguments
- skip `fmt.Sprintf` and `proxy_log` when debug logging is disabled
- preserve compatibility with hosts that do not expose `get_log_level`
- cover both disabled and enabled debug logging paths

Tracks higress-group/higress#4657

## Testing

- `go test ./proxywasm/...`

A full `go test ./...` was also attempted; unit packages pass, while existing e2e tests fail to start Envoy because their generated `main.wasm` files are absent.